### PR TITLE
Feature lifecycle hooks

### DIFF
--- a/docs/api/create-component/create-component.md
+++ b/docs/api/create-component/create-component.md
@@ -34,6 +34,12 @@
       - [`mutator`](#mutator)
       - [`preserve`](#preserve)
       - [`type`](#type)
+    - [`onIDSet`](#onidset)
+    - [`onScopeCreated`](#onscopecreated)
+    - [`onAttributesSet`](#onattributesset)
+    - [`onDynamicDataCreated`](#ondynamicdatacreated)
+    - [`onTransformationCompleted`](#ontransformationcompleted)
+    - [`onStylesAndEventsApplied`](#onstylesandeventsapplied)
     - [`props`](#props)
     - [`scope`](#scope)
     - [`src`](#src)
@@ -84,6 +90,12 @@ The options are utilities that are used to create and manipulate a component.
   markup: string,
   middleware: Object,
   mutations: Object,
+  onIDSet: Function,
+  onScopeCreated: Function,
+  onAttributesSet: Function,
+  onDynamicDataCreated: Function,
+  onTransformationCompleted: Function,
+  onStylesAndEventsApplied: Function,
   props: Object,
   scope: Element,
   src: string,
@@ -356,6 +368,30 @@ Indicates which parts of an element should be kept after cloning. Refer to [`mut
 #### `type`
 
 Indicates the type of mutation you want to apply. Refer to [`mutations`](../component/apply.md#mutations) for more details.
+
+### `onIDSet`
+
+A lifecycle hook called after the ID of the component has been set. Refer to [Lifecycle hooks](./lifecycle-hooks.md) for more information.
+
+### `onScopeCreated`
+
+A lifecycle hook called after the element of the component has been created. Refer to [Lifecycle hooks](./lifecycle-hooks.md) for more information.
+
+### `onAttributesSet`
+
+A lifecycle hook called after the attributes of the component have been set. Refer to [Lifecycle hooks](./lifecycle-hooks.md) for more information.
+
+### `onDynamicDataCreated`
+
+A lifecycle hook called after the [dynamic data](../component/component.md#dynamicData) of the component have been created. Refer to [Lifecycle hooks](./lifecycle-hooks.md) for more information.
+
+### `onTransformationCompleted`
+
+A lifecycle hook called after [transformations](../component/transform.md) of the component have been completed. Refer to [Lifecycle hooks](./lifecycle-hooks.md) for more information.
+
+### `onStylesAndEventsApplied`
+
+A lifecycle hook called after the [styles](#styles) and [event listeners](#eventlisteners) of the component have been applied. Refer to [Lifecycle hooks](./lifecycle-hooks.md) for more information.
 
 ### `props`
 

--- a/docs/api/create-component/lifecycle-hooks.md
+++ b/docs/api/create-component/lifecycle-hooks.md
@@ -1,0 +1,28 @@
+# Lifecycle Hooks
+
+## Description
+
+Lifecycle hooks are methods called at specific stages of the lifecycle of a component. They are called immediately after certain processes have occurred. The names of the methods describe the processes after which they are called. For example, [`onIDSet`](./create-component.md#onidset) is invoked immediately after the ID of the component has been set.
+
+## Syntax
+
+```js
+lifecycleHook(component)
+```
+
+Replace `lifecycleHood` with a name for a lifecycle hook. For example the lifecycle hook `onIDSet` would have the following syntax:
+
+```js
+onIDSet(component)
+```
+
+## Parameters
+
+- `compnent`:
+  - Type: `Object`
+  - Required: No.
+  - Usage: The component whose lifecycle the method is called on.
+
+## Return Value
+
+`undefined` or a promise that resolves to `undefined`.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -13,7 +13,7 @@ This is a documentation of upcoming releases. Only minor and major releases are 
 
 ### Progress
 
-- [ ] Add lifecycle hooks.
+- [x] Add lifecycle hooks.
 - [ ] Add customized component as a parameter to [`createComponent`](api/create-component/create-component.md).
 
 ### Release Date

--- a/src/create-component.js
+++ b/src/create-component.js
@@ -14,7 +14,7 @@ export const createComponent = async (options) => {
   }
 
   if (options.props && "id" in options.props) delete options.props.id;
-  await transform($component, options);
+  await initialize($component, options);
 
   return $component;
 };
@@ -33,7 +33,7 @@ const importOptions = async ({ src, importType = "module", extension }) => {
   return extension ? { ...imported, ...extension } : json;
 };
 
-const transform = async ($component, options) => {
+const initialize = async ($component, options) => {
   const {
     id,
     props,
@@ -45,24 +45,36 @@ const transform = async ($component, options) => {
     classes,
     attributes,
     utils,
-    middleware = {}
+    middleware = {},
+    onIDSet,
+    onScopeCreated,
+    onAttributesSet,
+    onDynamicDataCreated,
+    onTransformationCompleted,
+    onStylesAndEventsApplied
   } = options;
 
   $component.setID(id);
   $component.setProps(props);
+  onIDSet && (await onIDSet($component));
 
   if (scope) $component.scope = scope;
   else if (markup) await $component.parseMarkup(markup, middleware.markup);
 
+  onScopeCreated && (await onScopeCreated($component));
   attributes && (await $component.apply.attributes(attributes));
   classes && (await $component.apply.classes(classes));
   inlineStyles && (await $component.apply.inlineStyles(inlineStyles));
+  onAttributesSet && (await onAttributesSet($component));
   const { data: { dynamic } = {} } = utils || { data: {} };
   if (dynamic) await $component.createDynamicData(dynamic);
   if (dynamic) utils.data.dynamic = undefined;
+  onDynamicDataCreated && (await onDynamicDataCreated($component));
   await $component.transform.run({ props, utils, dynamicData: $component.dynamicData });
+  onTransformationCompleted && (await onTransformationCompleted($component));
   const promises = [];
   styles && promises.push($component.apply.styles(styles, middleware.styles));
   eventListeners && promises.push($component.apply.eventListeners(eventListeners));
   promises.length && (await Promise.all(promises));
+  onStylesAndEventsApplied && (await onStylesAndEventsApplied($component));
 };

--- a/tests/functionality/api/create-component.js
+++ b/tests/functionality/api/create-component.js
@@ -1,15 +1,56 @@
 import { createComponent } from "/src/main.js";
 import logResult from "/tests/functionality/log-result.js";
 
-
 const _createComponent = async () => {
-  const markup = /* html */`<div></div>`;
-  const options = { markup };
+  const markup = /* html */ `
+    <div>
+      <span odom-text="test"></span>
+    </div>
+  `;
+
+  let passed = false;
+
+  const onIDSet = async (component) => (passed = !!component.id);
+  const onScopeCreated = async (component) => (passed = passed && component.scope);
+  const onAttributesSet = async (component) => (passed = passed && component.scope.getAttribute("data-test"));
+  const onDynamicDataCreated = async (component) => (passed = passed && component.dynamicData.test);
+
+  const onTransformationCompleted = async (component) => {
+    passed = passed && component.scope.textContent.includes("test");
+  };
+
+  const onStylesAndEventsApplied = async (component) => {
+    passed = passed && getComputedStyle(component.scope).getPropertyValue("width") === "500px";
+  };
+
+  const options = {
+    markup,
+    styles: `
+      :scope {width: 500px;}
+    `,
+    attributes: {
+      "data-test": "test"
+    },
+    utils: {
+      data: {
+        dynamic: {
+          test: "test"
+        }
+      },
+      texts: { test: "test" }
+    },
+    onIDSet,
+    onScopeCreated,
+    onAttributesSet,
+    onDynamicDataCreated,
+    onTransformationCompleted,
+    onStylesAndEventsApplied
+  };
+
   const CreateComponent = await createComponent(options);
-  const passed = CreateComponent.scope.tagName === "DIV";
+  passed = CreateComponent.scope.tagName === "DIV";
   logResult(passed);
   return CreateComponent;
 };
-
 
 export default _createComponent;


### PR DESCRIPTION
- Add lifecycle hooks to 'createComponent'.
- Do this to enable inserting of processes at particular stages in the processes run by 'createComponent'.