### PR TITLE
Fix id param missing scope styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "odom",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.13.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "odom",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A JavaScript framework for building user interfaces.",
   "main": "dist/main.js",
   "files": [

--- a/src/component/apply/styles/scope-css.js
+++ b/src/component/apply/styles/scope-css.js
@@ -1,5 +1,5 @@
-export const scopeCSS = async (css, attributeSelector) => {
-  if (!attributeSelector) attributeSelector = `[odom-scope="${id}"]`;
+export const scopeCSS = async (css, id) => {
+  const attributeSelector = `[odom-scope="${id}"]`;
   let scopedSelector = attributeSelector;
 
   const regexes = {
@@ -27,7 +27,7 @@ export const scopeCSS = async (css, attributeSelector) => {
 
   const scopeSelector = (selector) => {
     const scopeAtRule = () => {
-      const scopeKeyframesName = (match, keyframesName) => ` ${keyframesName}-${id.replace(".", "-")}`;
+      const scopeKeyframesName = (match, keyframesName) => ` ${keyframesName}-${id}`;
 
       return selector.startsWith("@keyframes") ? selector.replace(regexes.keyframesName, scopeKeyframesName) : selector;
     };

--- a/src/component/apply/styles/styles.js
+++ b/src/component/apply/styles/styles.js
@@ -20,7 +20,7 @@ export const styles = async function (styles, middleware = {}) {
     });
   }
 
-  if (scope) styles = await scopeCSS(styles, this.selector);
+  if (scope) styles = await scopeCSS(styles, this.id);
   const styleElement = createStyleElement(styles, this.id);
   const head = document.querySelector("head");
   head.appendChild(styleElement);


### PR DESCRIPTION
- Fix error reported for id not being defined when using animations in styles
- Use 'id' as param instead of 'scopeSelector'.
- Create 'scopeSelector' from 'id'.