### PR TITLE
feat: allow JSON for collections to start with space

### DIFF
--- a/src/component/transform/collections/map.js
+++ b/src/component/transform/collections/map.js
@@ -8,7 +8,7 @@ export const map = async ({ element, props, data, methods }) => {
   let limits, cache, getMapData, createNode, mapDataSelector, mapData, reactive;
 
   if (value.startsWith("@")) mapDataSelector = value;
-  else if (value.startsWith("{")) {
+  else if (/^\s*\{/.test(value)) {
     const options = JSON.parse(value);
     mapDataSelector = options.data;
     limits = options.range;

--- a/src/component/transform/collections/multiple.js
+++ b/src/component/transform/collections/multiple.js
@@ -7,7 +7,7 @@ export const multiple = async ({ element, props, data, methods }) => {
     limits;
 
   if (options.startsWith("@")) selector = options;
-  else if (options.startsWith("{")) {
+  else if (/^\s*\{/.test(options)) {
     const value = JSON.parse(options);
     selector = value.data;
     limits = value.range;


### PR DESCRIPTION
- Allow JSON values for attributes 'odom-map' and 'odom-multiple' to start with space characters.
- This permits more flexible values.